### PR TITLE
Bump sharp from 0.26.2 to 0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "./lib",
   "dependencies": {
     "aws-sdk": "^2.775.0",
-    "sharp": "^0.26.2"
+    "sharp": "0.28.1"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
I experienced issue running this plugin along with strapi 3.6.0+beta.2. Something seems off with the sharp binaries because of the different sharp versions.

```
Bail out! GLib-GObject:ERROR:../gobject/gvaluetypes.c:454:_g_value_types_init: assertion failed: (type == G_TYPE_CHAR)
```

This issue seems related: https://github.com/lovell/sharp/issues/2356