### PR TITLE
Bump sharp version now that strapi upload plugin is 0.29.0 too

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "./lib",
   "dependencies": {
     "aws-sdk": "^2.775.0",
-    "sharp": "0.27.2"
+    "sharp": "0.29.0"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
strapi's upload is now using sharp 0.29.0, so I'm bumping sharp to allow m1 user to use your lib